### PR TITLE
fix mutation sync issue in removeImage function

### DIFF
--- a/src/components/Rearrange/Customizer.vue
+++ b/src/components/Rearrange/Customizer.vue
@@ -77,8 +77,12 @@ Agent
 	})
 
 function removeImage(id) {
-	data.value.content.images = data.value.content.images
-		.filter(obj => obj.id !== id)
+	const imageDataCopy = JSON.parse(JSON.stringify(imageData));
+	const index = imageDataCopy.findIndex(image => image.id === id);
+	imageDataCopy.splice(index, 1);
+
+	data.value.content.images = imageDataCopy;
+	imageData = imageDataCopy;
 }
 
 function onDragEnd(event) {


### PR DESCRIPTION
When removing images multiple times in the rearrange type of questions ( in preview ) there was an error: "Cannot add mutable state to multiple mutable parents."

I modified the removeImage function and used splice instead of filter to directly mutate the array. 